### PR TITLE
s/font.getfont()/font.fonts[]/

### DIFF
--- a/luatexko.lua
+++ b/luatexko.lua
@@ -531,7 +531,7 @@ local function get_font_table (fid)
     if fontdata[fid] then
       return fontdata[fid]
     else
-      return font.getfont(fid)
+      return font.fonts[fid]
     end
   end
 end


### PR DESCRIPTION
`font.getfont()` has been overloaded in the font loader (see `font-def.lua`). For raw access to the fonts table you need to resort to indexing `font.fonts` now.
