### PR TITLE
2020 expl3 deprecation removals

### DIFF
--- a/luatexko.sty
+++ b/luatexko.sty
@@ -411,7 +411,7 @@
   {
     \fontfamily \luatexkomainhangulfamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \rmdefault
+  \str_if_eq:eeT \familydefault \rmdefault
   {
     \cs_set_eq:NN \luatexkohangulfont \luatexkomainhangulfont
     \luatexkohangulselectfont
@@ -425,7 +425,7 @@
   {
     \fontfamily \luatexkosanshangulfamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \sfdefault
+  \str_if_eq:eeT \familydefault \sfdefault
   {
     \cs_set_eq:NN \luatexkohangulfont \luatexkosanshangulfont
     \luatexkohangulselectfont
@@ -439,7 +439,7 @@
   {
     \fontfamily \luatexkomonohangulfamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \ttdefault
+  \str_if_eq:eeT \familydefault \ttdefault
   {
     \cs_set_eq:NN \luatexkohangulfont \luatexkomonohangulfont
     \luatexkohangulselectfont
@@ -480,7 +480,7 @@
   {
     \fontfamily \luatexkomainhanjafamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \rmdefault
+  \str_if_eq:eeT \familydefault \rmdefault
   {
     \cs_set_eq:NN \luatexkohanjafont \luatexkomainhanjafont
     \luatexkohanjaselectfont
@@ -494,7 +494,7 @@
   {
     \fontfamily \luatexkosanshanjafamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \sfdefault
+  \str_if_eq:eeT \familydefault \sfdefault
   {
     \cs_set_eq:NN \luatexkohanjafont \luatexkosanshanjafont
     \luatexkohanjaselectfont
@@ -508,7 +508,7 @@
   {
     \fontfamily \luatexkomonohanjafamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \ttdefault
+  \str_if_eq:eeT \familydefault \ttdefault
   {
     \cs_set_eq:NN \luatexkohanjafont \luatexkomonohanjafont
     \luatexkohanjaselectfont
@@ -550,7 +550,7 @@
   {
     \fontfamily \luatexkomainfallbackfamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \rmdefault
+  \str_if_eq:eeT \familydefault \rmdefault
   {
     \cs_set_eq:NN \luatexkofallbackfont \luatexkomainfallbackfont
     \luatexkofallbackselectfont
@@ -564,7 +564,7 @@
   {
     \fontfamily \luatexkosansfallbackfamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \sfdefault
+  \str_if_eq:eeT \familydefault \sfdefault
   {
     \cs_set_eq:NN \luatexkofallbackfont \luatexkosansfallbackfont
     \luatexkofallbackselectfont
@@ -578,7 +578,7 @@
   {
     \fontfamily \luatexkomonofallbackfamily \selectfont
   }
-  \str_if_eq_x:nnT \familydefault \ttdefault
+  \str_if_eq:eeT \familydefault \ttdefault
   {
     \cs_set_eq:NN \luatexkofallbackfont \luatexkomonofallbackfont
     \luatexkofallbackselectfont


### PR DESCRIPTION
\str_if_eq_x:nn(TF) is deprecated and will be removed by the end of 2019. \str_if_eq:ee(TF) should be used insted.