### PR TITLE
Refactor luatexko

### DIFF
--- a/README
+++ b/README
@@ -12,7 +12,6 @@ this package to run.
 
 This package also requires cjk-ko package for its full functionality.
 
-
 License
 -------
 
@@ -21,7 +20,6 @@ This package is licensed under [LPPL](http://latex-project.org/lppl/)
 
 See each file for details.
 
-
 Author
 ------
 
@@ -29,10 +27,9 @@ Author
     Soojin Nam <jsunam at gmail com>
 
 Please report any errors or suggestions to
-    Dohyun Kim <nomosnomos at gmail com> (current maintainer)
+    Dohyun Kim &lt;nomosnomos at gmail com&gt; (current maintainer)
 or leave messages in the issue tracker at:
     <http://github.com/dohyunkim/luatexko>
-
 
 Files
 -----
@@ -51,7 +48,6 @@ Documents
     README (this file)      -> doc/luatex/luatexko/
     ChangeLog               -> doc/luatex/luatexko/
 
-
 Loading
 -------
 
@@ -68,7 +64,6 @@ Under plain TeX:
 
     \input luatexko.sty
 
-
 Package Options
 ---------------
 
@@ -78,7 +73,6 @@ interline spacing. Declares \hangulpunctuations=1 as well.
 
     [hanja]
 Load Hanja captions. Also apply other settings as [hangul] option does.
-
 
 Hangul Font Commands
 --------------------
@@ -112,7 +106,6 @@ In like manner, these commands are available as well:
 If any of these CJK fonts are not specified, UnBatang/UnDotum TrueType
 fonts will be used for typesetting CJK characters.
 
-
 Hangul Font Options
 -------------------
 
@@ -132,7 +125,7 @@ Set stretching of the glue between CJK characters.
 Set the penalty (default: 50) inserted between CJK characters.
 
     [CharRaise=<dimen>]
-Raise CJK characters by <dimen>.
+Raise CJK characters by &lt;dimen&gt;.
 
     [CompressPunctuations]
 Make CJK punctuations half-width.
@@ -144,7 +137,7 @@ Other User Commands
 -------------------
 
     \hangulpunctuations=<number>
-When <number> is 1 or greater (being default value), latin punctuations
+When &lt;number&gt; is 1 or greater (being default value), latin punctuations
 will be typeset with hangul fonts.
 
     \dotemph{...}
@@ -167,8 +160,8 @@ Command/environment for typesetting old document in horizontal writing mode.
 
     \begin{vertical}{<dimen>}
     \end{vertical}
-This environment makes a box vertically typeset. <dimen> is an
-argument to indicate the box height. When the <dimen> is \empty,
+This environment makes a box vertically typeset. &lt;dimen&gt; is an
+argument to indicate the box height. When the &lt;dimen&gt; is \empty,
 a box with natural height will result. For vertical writing of
 entire document, use the command \verticaltypesetting instead.
 
@@ -176,4 +169,4 @@ entire document, use the command \verticaltypesetting instead.
 Commands for automatic Josa selection. Unlike those of cjk-ko
 package, these commands work correctly even after Hangul or Hanja.
 
-*END of README*
+<!--END of README-->

--- a/luatexko.lua
+++ b/luatexko.lua
@@ -161,181 +161,125 @@ if harfbuzz then
   end
 end
 
+-- Each of these tables memoizes a per-font-id value: the __index metamethod
+-- computes the value once, caches it under the font id, and returns it.
+-- The pattern was identical for a dozen options, so we build them from a
+-- single factory. `compute` is called only with a truthy fid; when fid is
+-- falsy the metamethod yields `default` (nil unless given).
+local function memo_per_font (compute, default)
+  return setmetatable( {}, { __index = function(t, fid)
+    if not fid then return default end
+    local v = compute(fid)
+    t[fid] = v
+    return v
+  end } )
+end
+
 local fontoptions = {
-  is_widefont = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local fontdata = get_font_data(fid)
-      local format   = fontdata.format
-      local encode   = fontdata.encodingbytes
-      local bool     = encode == 2 or format == "opentype" or format == "truetype"
-      t[fid] = bool
-      return bool
-    end
-  end }),
+  is_widefont = memo_per_font(function(fid)
+    local fontdata = get_font_data(fid)
+    local format   = fontdata.format
+    local encode   = fontdata.encodingbytes
+    return encode == 2 or format == "opentype" or format == "truetype"
+  end),
 
-  is_hangulscript = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local bool = option_in_font(fid, "script") == "hang"
-      t[fid] = bool
-      return bool
-    end
-  end }),
+  is_hangulscript = memo_per_font(function(fid)
+    return option_in_font(fid, "script") == "hang"
+  end),
 
-  compresspunctuations = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local bool = option_in_font(fid, "compresspunctuations")
-                and not option_in_font(fid, "halt")
-                and not option_in_font(fid, "vhal")
-                or false
-      t[fid] = bool
-      return bool
-    end
-  end }),
+  compresspunctuations = memo_per_font(function(fid)
+    return option_in_font(fid, "compresspunctuations")
+       and not option_in_font(fid, "halt")
+       and not option_in_font(fid, "vhal")
+       or false
+  end),
 
-  removeclassicspaces = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local bool = option_in_font(fid, "removeclassicspaces") or false
-      t[fid] = bool
-      return bool
-    end
-  end }),
+  removeclassicspaces = memo_per_font(function(fid)
+    return option_in_font(fid, "removeclassicspaces") or false
+  end),
 
-  slantvalue = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local val = option_in_font(fid, "slant") or false
-      t[fid] = val
-      return val
-    end
-  end }),
+  slantvalue = memo_per_font(function(fid)
+    return option_in_font(fid, "slant") or false
+  end),
 
-  charraise = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local dim = font_opt_dim(fid, "charraise") or false
-      t[fid] = dim
-      return dim
-    end
-  end }),
+  charraise = memo_per_font(function(fid)
+    return font_opt_dim(fid, "charraise") or false
+  end),
 
-  intercharacter = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local dim = font_opt_dim(fid, "intercharacter") or false
-      t[fid] = dim
-      return dim
-    end
-  end }),
+  intercharacter = memo_per_font(function(fid)
+    return font_opt_dim(fid, "intercharacter") or false
+  end),
 
-  intercharstretch = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local dim = font_opt_dim(fid, "intercharstretch") or false
-      t[fid] = dim
-      return dim
-    end
-  end }),
+  intercharstretch = memo_per_font(function(fid)
+    return font_opt_dim(fid, "intercharstretch") or false
+  end),
 
-  intercharpenalty = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local pena = option_in_font(fid, "intercharpenalty") or false
-      t[fid] = pena
-      return pena
-    end
-  end }),
+  intercharpenalty = memo_per_font(function(fid)
+    return option_in_font(fid, "intercharpenalty") or false
+  end),
 
-  interhangul = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local dim = font_opt_dim(fid, "interhangul") or false
-      t[fid] = dim
-      return dim
-    end
-  end }),
+  interhangul = memo_per_font(function(fid)
+    return font_opt_dim(fid, "interhangul") or false
+  end),
 
-  interlatincjk = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local dim = font_opt_dim(fid, "interlatincjk") or false
-      t[fid] = dim
-      return dim
-    end
-  end }),
+  interlatincjk = memo_per_font(function(fid)
+    return font_opt_dim(fid, "interlatincjk") or false
+  end),
 
-  is_vertical = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local vertical = option_in_font(fid, "vertical") or false
-      t[fid] = vertical
-      return vertical
-    end
-  end }),
+  is_vertical = memo_per_font(function(fid)
+    return option_in_font(fid, "vertical") or false
+  end),
 
-  en_size = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local val = (get_font_param(fid, "quad") or 655360)/2
-      t[fid] = val
-      return val
-    end
-    return 327680
-  end } ),
+  en_size = memo_per_font(function(fid)
+    return (get_font_param(fid, "quad") or 655360)/2
+  end, 327680),
 
-  hangulspaceskip = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local newwd
-      if has_harf_data(fid) then
-        newwd = getparameters(fid) or false
-        if newwd then
-          newwd = { newwd.space, newwd.space_stretch, newwd.space_shrink, newwd.extra_space }
-        end
-      else
-        local newsp = nodenew(glyphid)
-        newsp.char, newsp.font = 32, fid
-        newsp = nodes.simple_font_handler(newsp) -- incorrect in vertical writing. backward compat.
-        newwd = newsp and newsp.width or false
-        if newwd then
-          newwd = { tex.sp(newwd), tex.sp(newwd/2), tex.sp(newwd/3), tex.sp(newwd/3) }
-        end
-        if newsp then nodefree(newsp) end
+  hangulspaceskip = memo_per_font(function(fid)
+    local newwd
+    if has_harf_data(fid) then
+      newwd = getparameters(fid) or false
+      if newwd then
+        newwd = { newwd.space, newwd.space_stretch, newwd.space_shrink, newwd.extra_space }
       end
-      t[fid] = newwd
-      return newwd
-    end
-  end } ),
-
-  monospaced = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      -- space_stretch has been set to zero by fontloader
-      if get_font_param(fid, "space_stretch") == 0 then
-        t[fid] = true; return true
+    else
+      local newsp = nodenew(glyphid)
+      newsp.char, newsp.font = 32, fid
+      newsp = nodes.simple_font_handler(newsp) -- incorrect in vertical writing. backward compat.
+      newwd = newsp and newsp.width or false
+      if newwd then
+        newwd = { tex.sp(newwd), tex.sp(newwd/2), tex.sp(newwd/3), tex.sp(newwd/3) }
       end
-      -- but not in harf mode; so we simply test widths of some glyphs
-      local chars = get_font_data(fid).characters or {}
-      local i, M = chars[0x69], chars[0x4D]
-      if i and M and i.width == M.width then
-        t[fid] = true; return true
-      end
-      t[fid] = false; return false
+      if newsp then nodefree(newsp) end
     end
-  end } ),
+    return newwd
+  end),
 
-  asc_desc = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local asc, desc = get_font_param(fid, "ascender"), get_font_param(fid, "descender")
-      -- luaharfbuzz's Font:get_h_extents() gets ascender value from hhea table;
-      -- Node mode's parameters.ascender is gotten from OS/2 table.
-      -- TypoAscender in OS/2 table seems to be more suitable for our purpose.
-      if not (asc and desc) then
-        asc, desc = get_asc_desc(has_harf_data(fid))
-      end
-      asc, desc  = asc  or false, desc or false
-      t[fid] = { asc, desc }
-      return { asc, desc }
+  monospaced = memo_per_font(function(fid)
+    -- space_stretch has been set to zero by fontloader
+    if get_font_param(fid, "space_stretch") == 0 then
+      return true
     end
-    return { }
-  end } ),
+    -- but not in harf mode; so we simply test widths of some glyphs
+    local chars = get_font_data(fid).characters or {}
+    local i, M = chars[0x69], chars[0x4D]
+    return i and M and i.width == M.width or false
+  end),
 
-  vertcharraise = setmetatable( {}, { __index = function(t, fid)
-    if fid then
-      local fontdata = get_font_data(fid)
-      local vertraise = fontdata and fontdata.vertcharraise or false
-      t[fid] = vertraise
-      return vertraise
+  asc_desc = memo_per_font(function(fid)
+    local asc, desc = get_font_param(fid, "ascender"), get_font_param(fid, "descender")
+    -- luaharfbuzz's Font:get_h_extents() gets ascender value from hhea table;
+    -- Node mode's parameters.ascender is gotten from OS/2 table.
+    -- TypoAscender in OS/2 table seems to be more suitable for our purpose.
+    if not (asc and desc) then
+      asc, desc = get_asc_desc(has_harf_data(fid))
     end
-  end } ),
+    return { asc or false, desc or false }
+  end, { }),
+
+  vertcharraise = memo_per_font(function(fid)
+    local fontdata = get_font_data(fid)
+    return fontdata and fontdata.vertcharraise or false
+  end),
 
   hb_char_bbox = { }, -- for vertical writing or fake slant
   tsb_data = { }, -- for vertical writing

--- a/luatexko.lua
+++ b/luatexko.lua
@@ -747,12 +747,10 @@ local function process_fonts (head)
             curr.font = hjf
           elseif not char_in_font(curr.font, c) then
             local fbf = has_attribute(curr, fallbackfontattr) or false
-            for _,f in ipairs{ hf, hjf, fbf } do
-              if f and char_in_font(f, c) then
-                curr.font = f
-                break
-              end
-            end
+            local f = hf  and char_in_font(hf,  c) and hf
+                   or hjf and char_in_font(hjf, c) and hjf
+                   or fbf and char_in_font(fbf, c) and fbf
+            if f then curr.font = f end
           end
         end
       end


### PR DESCRIPTION
동작에는 영향을 끼치지 않으면서 효율성과 가독성을 높일 수 있도록 간단히 수정해보았습니다.
검토 부탁드립니다.

1. [luatexko.lua:164-338](https://github.com/dohyunkim/luatexko/blob/master/luatexko.lua#L164-L338)의 폰트별 캐시들이 거의 전부 같은 골격을 복사하고 있는 것으로 보입니다. 팩토리 기반으로 정리했습니다.
  - `memo_per_font(compute, default)` 헬퍼 도입 — `__index`가 값을 한 번 계산해 폰트 id로 캐시하고 반환하는 동일 패턴을 한곳에 모았습니다. 메타테이블 메모이제이션이라는 기존의 좋은 성능 패턴은 그대로 유지됩니다.
  - 열두 개 남짓의 옵션이 한 줄 선언으로 — `removeclassicspaces`, `slantvalue`, `charraise`, `intercharacter`, `intercharstretch`, `intercharpenalty`, `interhangul`, `interlatincjk`, `is_vertical`, `is_hangulscript`, `compresspunctuations` 등.
  - `en_size`(기본값 327680)와 `asc_desc`(기본값 `{}`) 는 falsy-fid 기본값을 팩토리의 두 번째 인자로 넘겼습니다.
  - 복잡한 셋(`is_widefont`, `hangulspaceskip`, `monospaced`, `asc_desc`)도 같은 팩토리를 쓰되 계산부는 온전히 보존했고, `hangulspaceskip`의 backward-compat 주석과 `asc_desc`의 OS/2 관련 주석, `monospaced`의 설명 주석도 그대로 남겼습니다.
2. `process_fonts`함수는 모든 문서의 모든 글자를 도는 최고 빈도의 경로인데, 폴백이 필요한 글자마다 `{ hf, hjf, fbf }` [테이블을 새로 만듭니다.](https://github.com/dohyunkim/luatexko/blob/master/luatexko.lua#L804-L806) 명시적 분기로 풀면 할당이 사라집니다.
```lua
local fbf = has_attribute(curr, fallbackfontattr) or false
local f = hf  and char_in_font(hf,  c) and hf
       or hjf and char_in_font(hjf, c) and hjf
       or fbf and char_in_font(fbf, c) and fbf
if f then curr.font = f end
```
3. 마크다운이라고 명시하지는 않았지만, md 형식의 README 파일의 markdownlint 경고를 없앴습니다.

1, 2번 수정후 `make doc`으로 에러없이 luatex-ko 간단 메뉴얼이 만들어지는 것과 문서를 직접 눈으로 확인하는 것으로 테스트를 대신했습니다. 결과물이 문서라 눈으로 확인하는 것이 제일이지만 `make test`같은 테스트 슈트같은 것이 있으면 좋을 것 같습니다. (그런데 테스트 케이스를 어떻게 만들어야 할지도 쉽지 않겠네요.)