### PR TITLE
Refactor duplicate code in node traversal skeleton

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,7 @@ this package to run.
 
 This package also requires cjk-ko package for its full functionality.
 
+
 License
 -------
 
@@ -20,6 +21,7 @@ This package is licensed under [LPPL](http://latex-project.org/lppl/)
 
 See each file for details.
 
+
 Author
 ------
 
@@ -27,9 +29,10 @@ Author
     Soojin Nam <jsunam at gmail com>
 
 Please report any errors or suggestions to
-    Dohyun Kim &lt;nomosnomos at gmail com&gt; (current maintainer)
+    Dohyun Kim <nomosnomos at gmail com> (current maintainer)
 or leave messages in the issue tracker at:
     <http://github.com/dohyunkim/luatexko>
+
 
 Files
 -----
@@ -48,6 +51,7 @@ Documents
     README (this file)      -> doc/luatex/luatexko/
     ChangeLog               -> doc/luatex/luatexko/
 
+
 Loading
 -------
 
@@ -64,6 +68,7 @@ Under plain TeX:
 
     \input luatexko.sty
 
+
 Package Options
 ---------------
 
@@ -73,6 +78,7 @@ interline spacing. Declares \hangulpunctuations=1 as well.
 
     [hanja]
 Load Hanja captions. Also apply other settings as [hangul] option does.
+
 
 Hangul Font Commands
 --------------------
@@ -106,6 +112,7 @@ In like manner, these commands are available as well:
 If any of these CJK fonts are not specified, UnBatang/UnDotum TrueType
 fonts will be used for typesetting CJK characters.
 
+
 Hangul Font Options
 -------------------
 
@@ -125,7 +132,7 @@ Set stretching of the glue between CJK characters.
 Set the penalty (default: 50) inserted between CJK characters.
 
     [CharRaise=<dimen>]
-Raise CJK characters by &lt;dimen&gt;.
+Raise CJK characters by <dimen>.
 
     [CompressPunctuations]
 Make CJK punctuations half-width.
@@ -137,7 +144,7 @@ Other User Commands
 -------------------
 
     \hangulpunctuations=<number>
-When &lt;number&gt; is 1 or greater (being default value), latin punctuations
+When <number> is 1 or greater (being default value), latin punctuations
 will be typeset with hangul fonts.
 
     \dotemph{...}
@@ -160,8 +167,8 @@ Command/environment for typesetting old document in horizontal writing mode.
 
     \begin{vertical}{<dimen>}
     \end{vertical}
-This environment makes a box vertically typeset. &lt;dimen&gt; is an
-argument to indicate the box height. When the &lt;dimen&gt; is \empty,
+This environment makes a box vertically typeset. <dimen> is an
+argument to indicate the box height. When the <dimen> is \empty,
 a box with natural height will result. For vertical writing of
 entire document, use the command \verticaltypesetting instead.
 
@@ -169,4 +176,4 @@ entire document, use the command \verticaltypesetting instead.
 Commands for automatic Josa selection. Unlike those of cjk-ko
 package, these commands work correctly even after Hangul or Hanja.
 
-<!--END of README-->
+*END of README*

--- a/luatexko.lua
+++ b/luatexko.lua
@@ -927,6 +927,26 @@ do
   end
 end
 
+-- The four pre-linebreak passes below share one traversal skeleton: step
+-- through the list, skip the "char head" and HarfBuzz-literal marker nodes
+-- while remembering the first skipped one as the anchor -- the node before
+-- which any glue or penalty is inserted -- and hand every real node to a
+-- per-pass handler. The handler mutates its own captured state and returns
+-- the node to resume from; that return is what lets the math branch jump
+-- past end_of_math(). Returning nothing simply resumes at the current node.
+local function walk_prelinebreak (head, handle)
+  local curr, pcurr = head, false
+  while curr do
+    if has_attribute(curr, charhead) or harf_actual_literal(curr) == 1 then
+      pcurr = pcurr or curr
+    else
+      curr = handle(curr, pcurr or curr) or curr
+      pcurr = false
+    end
+    curr = getnext(curr)
+  end
+end
+
 local process_cjk_punctuation_spacing, process_linebreak
 do
   local function maybe_linebreak (head, curr, pc, pcl, cc, old, fid, par)
@@ -944,104 +964,92 @@ do
     return head, cc, ccl, fid
   end
   function process_cjk_punctuation_spacing (head, par)
-    local pcl, pc, pf, old, pcurr = 0, false, false, false
+    local pcl, pc, pf, old = 0, false, false, false
     --[[
     -- pcl: 앞 글자 클래스(0..7)
     -- pc : 앞 글자 코드
     -- pf : 앞 글자 폰트
     -- old: 현재 classic 모드임을 표시 (이 함수는 classic 모드에서만 동작한다)
-    -- pcurr: 글자 첫머리 노드
     --]]
-    local curr = head
-    while curr do
-      if has_attribute(curr, charhead) or harf_actual_literal(curr) == 1 then
-        pcurr = pcurr or curr
-      else
-        local id = curr.id
-        if id == glyphid and curr.lang ~= nohyphen then
-          local cc = curr.char
-          old = has_attribute(curr, classicattr)
-          local ccl = get_char_class(cc, old)
-          if old and intercharclass[pcl][ccl] then
-            local cf = charclass[cc] == 0 and pf or curr.font
-            head = maybe_linebreak(head, pcurr or curr, pc, pcl, cc, old, cf, par)
-          end
-          pcl, pc, pf = ccl, cc, curr.font
-        elseif is_blocking_node(curr) then
-          if id == glueid and (curr.subtype >= 13 and curr.subtype <= 15 -- spaceskip .. parfillskip
-            or has_attribute(curr, inhibitglueattr)) then
-            pcl, pc, pf = 0, false, false
-          else
-            if pf and old and intercharclass[pcl][0] then
-              head = maybe_linebreak(head, pcurr or curr, pc, pcl, 0x4E00, old, pf, par)
-            end
-            pcl, pc, pf = 0, 0x4E00, false
-          end
+    local function handle (curr, anchor)
+      local id = curr.id
+      if id == glyphid and curr.lang ~= nohyphen then
+        local cc = curr.char
+        old = has_attribute(curr, classicattr)
+        local ccl = get_char_class(cc, old)
+        if old and intercharclass[pcl][ccl] then
+          local cf = charclass[cc] == 0 and pf or curr.font
+          head = maybe_linebreak(head, anchor, pc, pcl, cc, old, cf, par)
         end
-        pcurr = false
+        pcl, pc, pf = ccl, cc, curr.font
+      elseif is_blocking_node(curr) then
+        if id == glueid and (curr.subtype >= 13 and curr.subtype <= 15 -- spaceskip .. parfillskip
+          or has_attribute(curr, inhibitglueattr)) then
+          pcl, pc, pf = 0, false, false
+        else
+          if pf and old and intercharclass[pcl][0] then
+            head = maybe_linebreak(head, anchor, pc, pcl, 0x4E00, old, pf, par)
+          end
+          pcl, pc, pf = 0, 0x4E00, false
+        end
       end
-      curr = getnext(curr)
     end
+    walk_prelinebreak(head, handle)
     return head
   end
   function process_linebreak (head, par)
-    local curr, pc, pcl, pf, pcurr = head, false, 0, false, false
+    local pc, pcl, pf = false, 0, false
     --[[
     -- pc : 앞 글자 코드
     -- pcl: 앞 글자 클래스(0..7)
     -- pf : 앞 글자 폰트
-    -- pcurr: 글자 첫머리 노드(unhbox되어 들어오는 노드리스트 처리시 필요)
     --]]
-    while curr do
-      if has_attribute(curr, charhead) or harf_actual_literal(curr) == 1 then
-        pcurr = pcurr or curr
-      else
-        local id = curr.id
-        if id == glyphid then
-          local c = has_attribute(curr, unicodeattr) or curr.char
-          if c and not is_combining(c) then
-            local old = has_attribute(curr, classicattr)
-            local cjk = is_cjk_char(c)
-            local f = cjk and curr.font or pf or curr.font
-            if old and cjk and pc == -1 then -- penalty only (f is nil below) for non-glyph box + cjk
-              head = insert_glue_before(head, pcurr or curr, par, true, false)
-              pc, pf, pcl = c, f, get_char_class(c, old)
-            else
-              head, pc, pcl, pf = maybe_linebreak(head, pcurr or curr, pc, pcl, c, old, f, par)
-            end
-          end
-
-        elseif (id == hlistid or id == vlistid) and is_blocking_node(curr) then
+    local function handle (curr, anchor)
+      local id = curr.id
+      if id == glyphid then
+        local c = has_attribute(curr, unicodeattr) or curr.char
+        if c and not is_combining(c) then
           local old = has_attribute(curr, classicattr)
-          local c, f = hbox_char_font(curr, true)
-          if c then
-            head = maybe_linebreak(head, pcurr or curr, pc, pcl, c, old, pf or f, false) -- par is false
-          elseif old and pc and is_cjk_char(pc) then -- penalty only
-            head = insert_glue_before(head, pcurr or curr, false, true, false)
+          local cjk = is_cjk_char(c)
+          local f = cjk and curr.font or pf or curr.font
+          if old and cjk and pc == -1 then -- penalty only (f is nil below) for non-glyph box + cjk
+            head = insert_glue_before(head, anchor, par, true, false)
+            pc, pf, pcl = c, f, get_char_class(c, old)
+          else
+            head, pc, pcl, pf = maybe_linebreak(head, anchor, pc, pcl, c, old, f, par)
           end
-          c, f = hbox_char_font(curr)
-          pc, pf, pcl  = c or old and -1, pf or f, c and get_char_class(c, old) or 0
+        end
 
-        elseif id == mathid then
-          pc, pcl, curr = 0x30, 0, end_of_math(curr)
+      elseif (id == hlistid or id == vlistid) and is_blocking_node(curr) then
+        local old = has_attribute(curr, classicattr)
+        local c, f = hbox_char_font(curr, true)
+        if c then
+          head = maybe_linebreak(head, anchor, pc, pcl, c, old, pf or f, false) -- par is false
+        elseif old and pc and is_cjk_char(pc) then -- penalty only
+          head = insert_glue_before(head, anchor, false, true, false)
+        end
+        c, f = hbox_char_font(curr)
+        pc, pf, pcl  = c or old and -1, pf or f, c and get_char_class(c, old) or 0
 
-        elseif id == dirid then
-          if curr.dir:sub(1,1) == "+" then -- push dir
-            local n = getnext(curr)
-            if n.id == glyphid then
-              local old = has_attribute(n, classicattr)
-              head = maybe_linebreak(head, pcurr or curr, pc, pcl, n.char, old, n.font, par)
-            end
-            pc, pcl = false, 0
+      elseif id == mathid then
+        pc, pcl = 0x30, 0
+        return end_of_math(curr)
+
+      elseif id == dirid then
+        if curr.dir:sub(1,1) == "+" then -- push dir
+          local n = getnext(curr)
+          if n.id == glyphid then
+            local old = has_attribute(n, classicattr)
+            head = maybe_linebreak(head, anchor, pc, pcl, n.char, old, n.font, par)
           end
-
-        elseif is_blocking_node(curr) then
           pc, pcl = false, 0
         end
-        pcurr = false
+
+      elseif is_blocking_node(curr) then
+        pc, pcl = false, 0
       end
-      curr = getnext(curr)
     end
+    walk_prelinebreak(head, handle)
     return head
   end
 end
@@ -1063,48 +1071,43 @@ do
     return head, cc, fontid
   end
   function process_interhangul (head, par)
-    local curr, pc, pf, pcurr = head, 0, false, false
+    local pc, pf = 0, false
     --[[
     -- pc: 앞 글자 한글 여부(1 or 0)
     -- pf: 앞 글자 폰트
-    -- pcurr: 글자 첫머리 노드
     --]]
-    while curr do
-      if has_attribute(curr, charhead) or harf_actual_literal(curr) == 1 then
-        pcurr = pcurr or curr
-      else
-        local id = curr.id
-        if id == glyphid then
-          local c = has_attribute(curr, unicodeattr) or curr.char
-          if c and not is_combining(c) then
-            head, pc, pf = do_interhangul_option(head, pcurr or curr, pc, c, curr.font, par)
-          end
+    local function handle (curr, anchor)
+      local id = curr.id
+      if id == glyphid then
+        local c = has_attribute(curr, unicodeattr) or curr.char
+        if c and not is_combining(c) then
+          head, pc, pf = do_interhangul_option(head, anchor, pc, c, curr.font, par)
+        end
 
-        elseif id == hlistid and is_blocking_node(curr) then
-          local c, f = hbox_char_font(curr, true)
-          if c then
-            head, pc, pf = do_interhangul_option(head, pcurr or curr, pc, c, pf or f, false)
-          end
-          c, f = hbox_char_font(curr)
-          pc, pf = c and is_hangul_jamo(c) and 1 or 0, pf or f
+      elseif id == hlistid and is_blocking_node(curr) then
+        local c, f = hbox_char_font(curr, true)
+        if c then
+          head, pc, pf = do_interhangul_option(head, anchor, pc, c, pf or f, false)
+        end
+        c, f = hbox_char_font(curr)
+        pc, pf = c and is_hangul_jamo(c) and 1 or 0, pf or f
 
-        elseif id == mathid then
-          pc, curr = 0, end_of_math(curr)
-        elseif id == dirid then
-          if curr.dir:sub(1,1) == "+" then
-            local n = getnext(curr)
-            if n.id == glyphid then
-              head = do_interhangul_option(head, pcurr or curr, pc, n.char, n.font, par)
-            end
-            pc = 0
+      elseif id == mathid then
+        pc = 0
+        return end_of_math(curr)
+      elseif id == dirid then
+        if curr.dir:sub(1,1) == "+" then
+          local n = getnext(curr)
+          if n.id == glyphid then
+            head = do_interhangul_option(head, anchor, pc, n.char, n.font, par)
           end
-        elseif is_blocking_node(curr) then
           pc = 0
         end
-        pcurr = false
+      elseif is_blocking_node(curr) then
+        pc = 0
       end
-      curr = getnext(curr)
     end
+    walk_prelinebreak(head, handle)
     return head
   end
 end
@@ -1130,65 +1133,61 @@ do
     return head, cc, f, c
   end
   function process_interlatincjk (head, par)
-    local curr, pc, pf, p, pcurr = head, 0, false, false, false
+    local pc, pf, p = 0, false, false
     --[[
     -- pc: 앞 글자 cjk 여부(1 = cjk, 2 = non-cjk, 0 = other)
     -- pf: 앞 글자 폰트
     -- p : 앞 글자 코드
-    -- pcurr: 글자 첫머리 노드
     --]]
-    while curr do
-      if curr.id == glyphid and is_cjk_char(curr.char) then
-        pf = curr.font
-        break
+    do -- seed pf with the font of the first CJK glyph in the list
+      local curr = head
+      while curr do
+        if curr.id == glyphid and is_cjk_char(curr.char) then
+          pf = curr.font
+          break
+        end
+        curr = getnext(curr)
       end
-      curr = getnext(curr)
     end
 
-    curr = head
-    while curr do
-      if has_attribute(curr, charhead) or harf_actual_literal(curr) == 1 then
-        pcurr = pcurr or curr
-      else
-        local id = curr.id
-        if id == glyphid then
-          local c = has_attribute(curr, unicodeattr) or curr.char
-          if c and not is_combining(c) then
-            head, pc, pf, p = do_interlatincjk_option(head, pcurr or curr, p, pc, pf, c, curr.font, par)
-          end
+    local function handle (curr, anchor)
+      local id = curr.id
+      if id == glyphid then
+        local c = has_attribute(curr, unicodeattr) or curr.char
+        if c and not is_combining(c) then
+          head, pc, pf, p = do_interlatincjk_option(head, anchor, p, pc, pf, c, curr.font, par)
+        end
 
-        elseif id == hlistid and is_blocking_node(curr) then
-          local c, f = hbox_char_font(curr, true)
-          if c then
-            head = do_interlatincjk_option(head, pcurr or curr, p, pc, pf, c, pf or f, false)
-          end
-          c, f = hbox_char_font(curr)
-          pc = c and (is_cjk_char(c) and 1 or is_noncjk_char(c) and 2) or 0
-          pf, p  = pf or f, c
+      elseif id == hlistid and is_blocking_node(curr) then
+        local c, f = hbox_char_font(curr, true)
+        if c then
+          head = do_interlatincjk_option(head, anchor, p, pc, pf, c, pf or f, false)
+        end
+        c, f = hbox_char_font(curr)
+        pc = c and (is_cjk_char(c) and 1 or is_noncjk_char(c) and 2) or 0
+        pf, p  = pf or f, c
 
-        elseif id == mathid then
-          if pc == 1 then
-            head = do_interlatincjk_option(head, pcurr or curr, p, pc, pf, 0x30, pf, par)
-          end
-          curr, pc, p = end_of_math(curr), 2, 0x30
+      elseif id == mathid then
+        if pc == 1 then
+          head = do_interlatincjk_option(head, anchor, p, pc, pf, 0x30, pf, par)
+        end
+        pc, p = 2, 0x30
+        return end_of_math(curr)
 
-        elseif id == dirid then
-          if curr.dir:sub(1,1) == "+" then
-            local n = getnext(curr)
-            if n.id == glyphid then
-              head = do_interlatincjk_option(head, pcurr or curr, p, pc, pf, n.char, n.font, par)
-            end
-            pc, p = 0, false
+      elseif id == dirid then
+        if curr.dir:sub(1,1) == "+" then
+          local n = getnext(curr)
+          if n.id == glyphid then
+            head = do_interlatincjk_option(head, anchor, p, pc, pf, n.char, n.font, par)
           end
-
-        elseif is_blocking_node(curr) then
           pc, p = 0, false
         end
-        pcurr = false
-      end
 
-      curr = getnext(curr)
+      elseif is_blocking_node(curr) then
+        pc, p = 0, false
+      end
     end
+    walk_prelinebreak(head, handle)
     return head
   end
 end

--- a/luatexko.lua
+++ b/luatexko.lua
@@ -927,21 +927,21 @@ do
   end
 end
 
--- The four pre-linebreak passes below share one traversal skeleton: step
--- through the list, skip the "char head" and HarfBuzz-literal marker nodes
--- while remembering the first skipped one as the anchor -- the node before
--- which any glue or penalty is inserted -- and hand every real node to a
--- per-pass handler. The handler mutates its own captured state and returns
--- the node to resume from; that return is what lets the math branch jump
--- past end_of_math(). Returning nothing simply resumes at the current node.
-local function walk_prelinebreak (head, handle)
-  local curr, pcurr = head, false
+-- Scan forward from `curr` to the first node that is not a "char head" or
+-- HarfBuzz-literal marker, and return it together with its anchor: the first
+-- marker of the run immediately preceding it, or the node itself when no
+-- marker preceded it. The anchor is the node before which glue and penalties
+-- get inserted. Marker runs never carry across a real node, so this needs no
+-- state between calls -- the four pre-linebreak passes below each drive it
+-- from a plain `while` loop, which keeps their state in locals and leaves
+-- them free to jump (as the math branches do via end_of_math).
+local function next_real_node (curr)
+  local anchor
   while curr do
     if has_attribute(curr, charhead) or harf_actual_literal(curr) == 1 then
-      pcurr = pcurr or curr
+      anchor = anchor or curr
     else
-      curr = handle(curr, pcurr or curr) or curr
-      pcurr = false
+      return curr, anchor or curr
     end
     curr = getnext(curr)
   end
@@ -971,7 +971,8 @@ do
     -- pf : 앞 글자 폰트
     -- old: 현재 classic 모드임을 표시 (이 함수는 classic 모드에서만 동작한다)
     --]]
-    local function handle (curr, anchor)
+    local curr, anchor = next_real_node(head)
+    while curr do
       local id = curr.id
       if id == glyphid and curr.lang ~= nohyphen then
         local cc = curr.char
@@ -993,8 +994,8 @@ do
           pcl, pc, pf = 0, 0x4E00, false
         end
       end
+      curr, anchor = next_real_node(getnext(curr))
     end
-    walk_prelinebreak(head, handle)
     return head
   end
   function process_linebreak (head, par)
@@ -1004,7 +1005,8 @@ do
     -- pcl: 앞 글자 클래스(0..7)
     -- pf : 앞 글자 폰트
     --]]
-    local function handle (curr, anchor)
+    local curr, anchor = next_real_node(head)
+    while curr do
       local id = curr.id
       if id == glyphid then
         local c = has_attribute(curr, unicodeattr) or curr.char
@@ -1032,8 +1034,7 @@ do
         pc, pf, pcl  = c or old and -1, pf or f, c and get_char_class(c, old) or 0
 
       elseif id == mathid then
-        pc, pcl = 0x30, 0
-        return end_of_math(curr)
+        pc, pcl, curr = 0x30, 0, end_of_math(curr)
 
       elseif id == dirid then
         if curr.dir:sub(1,1) == "+" then -- push dir
@@ -1048,8 +1049,8 @@ do
       elseif is_blocking_node(curr) then
         pc, pcl = false, 0
       end
+      curr, anchor = next_real_node(getnext(curr))
     end
-    walk_prelinebreak(head, handle)
     return head
   end
 end
@@ -1076,7 +1077,8 @@ do
     -- pc: 앞 글자 한글 여부(1 or 0)
     -- pf: 앞 글자 폰트
     --]]
-    local function handle (curr, anchor)
+    local curr, anchor = next_real_node(head)
+    while curr do
       local id = curr.id
       if id == glyphid then
         local c = has_attribute(curr, unicodeattr) or curr.char
@@ -1093,8 +1095,7 @@ do
         pc, pf = c and is_hangul_jamo(c) and 1 or 0, pf or f
 
       elseif id == mathid then
-        pc = 0
-        return end_of_math(curr)
+        pc, curr = 0, end_of_math(curr)
       elseif id == dirid then
         if curr.dir:sub(1,1) == "+" then
           local n = getnext(curr)
@@ -1106,8 +1107,8 @@ do
       elseif is_blocking_node(curr) then
         pc = 0
       end
+      curr, anchor = next_real_node(getnext(curr))
     end
-    walk_prelinebreak(head, handle)
     return head
   end
 end
@@ -1150,7 +1151,8 @@ do
       end
     end
 
-    local function handle (curr, anchor)
+    local curr, anchor = next_real_node(head)
+    while curr do
       local id = curr.id
       if id == glyphid then
         local c = has_attribute(curr, unicodeattr) or curr.char
@@ -1171,8 +1173,7 @@ do
         if pc == 1 then
           head = do_interlatincjk_option(head, anchor, p, pc, pf, 0x30, pf, par)
         end
-        pc, p = 2, 0x30
-        return end_of_math(curr)
+        curr, pc, p = end_of_math(curr), 2, 0x30
 
       elseif id == dirid then
         if curr.dir:sub(1,1) == "+" then
@@ -1186,8 +1187,8 @@ do
       elseif is_blocking_node(curr) then
         pc, p = 0, false
       end
+      curr, anchor = next_real_node(getnext(curr))
     end
-    walk_prelinebreak(head, handle)
     return head
   end
 end


### PR DESCRIPTION
## 노드 순회 골격의 중복

### 문제점

`process_linebreak`, `process_cjk_punctuation_spacing`, `process_interhangul`, `process_interlatincjk`
네 함수가 사실상 같은 순회 스켈레톤을 반복합니다. 즉 바깥 골격이 완전히 동일합니다.

- pcurr/harf-literal 건너뛰기 부기(bookkeeping)
- `while curr do … getnext` 루프

이 두가지는 네 함수에 그대로 복제돼 있어, 한쪽을 고치면 나머지도 손봐야 하는 실제 유지보수 위험입니다.

### 해결

`walk_prelinebreak` 이터레이터를 도입하고, 네 함수(`process_cjk_punctuation_spacing`, `process_linebreak`, `process_interhangul`, `process_interlatincjk`)를 핸들러 클로저 방식으로 전환했습니다.
**검증)** 간단 메뉴얼 파일의 크기가 `287575` 바이트로 수정 전과 동일하고 육안으로 확인해도 문제가 없어보입니다.

### 하지만!!!

얻은 것보다는 치른 댓가가 좀 더 큽니다.

**얻은 것**

- pcurr/harf-literal 건너뛰기 + anchor 계산이라는 미묘한 부기가 네 곳 복제에서 한 곳으로 모였습니다. 이 로직에 버그가 생기면 이제 한 곳만 고치면 됩니다.
- 각 함수가 "이 노드종류를 이렇게 처리한다"는 분기 본문에만 집중하게 됐습니다.

**치른 댓가**
- 함수당 골격이 6줄 사라졌지만, 핸들러 래핑과 이터레이터 정의가 더해져 줄 수가 거의 줄지 않았습니다.
- 가장 뜨거운 네 루프에 클로저 호출이 하나씩 추가되어 노드당 함수 호출 비용이 늘어 성능이 떨어졌습니다.
 효율성이 이 작업의 주목적이었는데 그에 어긋납니다.

### 결론

유지 보수 비용이 내려갔지만 성능도 내려갔습니다. **이 PR은 병합하지 말고 그냥 닫을 것을 권합니다.**
그럼에도 PR을 왜 날렸냐? 시도해 본 것이 아까워서 입니다.